### PR TITLE
Add Swift version badge to README

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,3 @@
+version: 1
+external_links:
+  documentation: "https://ios-sdk.moneykit.com/documentation/moneykit"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MoneyKit for iOS
+# MoneyKit for iOS [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fmoneykit%2Fmoneykit-ios%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/moneykit/moneykit-ios)
 
 ## Overview
 


### PR DESCRIPTION
This adds the following:

- Swift version compatibility badge to the `README.md`.
- Swift Package Index .yml file with links to the externally hosted documentation.