### PR TITLE
Update MoneyKit.podspec for latest version (1.0.2)

### DIFF
--- a/MoneyKit.podspec
+++ b/MoneyKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'MoneyKit'
   s.module_name      = 'MoneyKit'
-  s.version          = '1.0.1'
+  s.version          = '1.0.2'
 
   s.summary          = 'MoneyKit for iOS is a quick and secure way to link bank accounts from within your iOS app.'
 


### PR DESCRIPTION
This updates the MoneyKit.podspec to use the [latest release](https://github.com/moneykit/moneykit-ios/releases/tag/1.0.2).